### PR TITLE
Update eclipse.gradle for importing gradle without compile errors into Eclipse

### DIFF
--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -13,12 +13,14 @@ allprojects {
                     classpath.entries.removeAll { it.path.contains("$project.name/build") && it.kind=='lib' }
                     // Remove references to other project's binaries
                     classpath.entries.removeAll { it.path.contains("/subprojects") && it.kind == 'lib' }
+                    // Add needed resources for running gradle as a non daemon java application
+                    classpath.entries.add(new org.gradle.plugins.ide.eclipse.model.SourceFolder("build/generated-resources/main", null))
                 }
             }
             jdt {
-                sourceCompatibility = '1.7'
-                targetCompatibility = '1.7'
-                javaRuntimeName = 'JavaSE-1.7'
+                sourceCompatibility = '1.8'
+                targetCompatibility = '1.8'
+                javaRuntimeName = 'JavaSE-1.8'
                 file.withProperties { properties ->
                     // Eclipse's view of projects treat circular dependencies as errors by default
                     properties["org.eclipse.jdt.core.circularClasspath"] = "warning"


### PR DESCRIPTION
Hi

This PR is a fix to the gradle/eclipse.gradle script. It permits to import later on all gradle projects with no compile errors in all src/main/java classes and most of all but few src/test/groovy classes.
By adding the build/generated-resource/main to the classpath of each project, gradle can run as a simple non daemon java application ready to be debugged under the Eclipse JDT debugger.

Using the JavaSE-1.8 is mandatory since JavaSE-1.7 compiles some gradle java classes with errors.
